### PR TITLE
chore: override tsc declaration config to true when bundling with rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,7 +31,13 @@ export default {
       "require.main === module": false
     }),
     typescript({
-      tsconfigOverride: { compilerOptions: { declaration: true } }
+      tsconfigOverride: {
+        compilerOptions: {
+          declaration: true,
+          declarationDir: "typings"
+        }
+      },
+      useTsconfigDeclarationDir: true
     }),
     resolve(),
     commonjs(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,9 @@ export default {
       // FastPriorityQueue has this nasty line that breaks iife
       "require.main === module": false
     }),
-    typescript(),
+    typescript({
+      tsconfigOverride: { compilerOptions: { declaration: true } }
+    }),
     resolve(),
     commonjs(),
     globals(),


### PR DESCRIPTION
This will generate the typescript typings when bundling with rollup. 

Fixes #45 

Open topic (which I cannot seem to find):
When a release is made, the `typings` directory should be included in the package.