### PR TITLE
publish types and provide esm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "email": "erik.brinkman@gmail.com"
   },
   "license": "MIT",
-  "main": "dist/d3-dag",
-  "module": "dist/d3-dag.esm",
+  "main": "dist/d3-dag.js",
+  "module": "dist/d3-dag.esm.js",
   "files": [
     "/src/**/*.js",
     "/src/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-dag",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Layout algorithms for visualizing directed acylic graphs.",
   "keywords": [
     "d3",
@@ -18,15 +18,16 @@
     "email": "erik.brinkman@gmail.com"
   },
   "license": "MIT",
-  "main": "dist/d3-dag.js",
+  "main": "dist/d3-dag",
+  "module": "dist/d3-dag.esm",
   "files": [
     "/src/**/*.js",
     "/src/**/*.ts",
     "/dist/d3-dag.js",
-    "/dist/d3-dag.min.js"
+    "/dist/d3-dag.min.js",
+    "/dist/d3-dag.esm.js"
   ],
-  "module": "src/index",
-  "jsnext:main": "src/index",
+  "types": "dist/index.d.ts",
   "unpkg": "dist/d3-dag.min.js",
   "jest": {
     "preset": "ts-jest",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,22 +7,27 @@ import replace from "@rollup/plugin-replace";
 import resolve from "@rollup/plugin-node-resolve";
 import { terser } from "rollup-plugin-terser";
 import typescript from "rollup-plugin-typescript2";
+import pkg from "./package.json";
 
 export default {
   input: "src/index.ts",
   output: [
-    {
-      file: "dist/d3-dag.js",
-      format: "umd",
-      name: "d3",
-      extend: true
-    },
     {
       file: "dist/d3-dag.min.js",
       format: "umd",
       name: "d3",
       extend: true,
       plugins: [terser()]
+    },
+    {
+      file: pkg.main,
+      format: "umd",
+      name: "d3",
+      extend: true
+    },
+    {
+      file: pkg.module,
+      format: "es"
     }
   ],
   plugins: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "./dist",
     "target": "ES6",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
this is my attempt to bring types to d3-dag. It is based on this tutorial https://hackernoon.com/building-and-publishing-a-module-with-typescript-and-rollup-js-faa778c85396 and tested locally.

this fixes #45 and #6 