### PR TITLE
Swap out `denque` for `quetie` for a smaller bundle size

### DIFF
--- a/bundle.test.ts
+++ b/bundle.test.ts
@@ -78,7 +78,7 @@ describe("tests that require a built bundle", () => {
     expect([[0], [1, 2], [3]]).toEqual(layers);
   });
 
-  // denque
+  // quetie
   test("slice() works with negatives", () => {
     const dag = d3dag.dagConnect()([
       ["0", "1"],

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
   },
   "dependencies": {
     "d3-array": "^3.0.1",
-    "denque": "^1.5.0",
     "fastpriorityqueue": "0.7.1",
     "javascript-lp-solver": "0.4.24",
-    "quadprog": "^1.6.1"
+    "quadprog": "^1.6.1",
+    "quetie": "^0.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",

--- a/src/iters.ts
+++ b/src/iters.ts
@@ -6,7 +6,7 @@
  *
  * @module
  */
-import Denque from "denque";
+import { Queue } from "quetie";
 
 /**
  * A fluent iterable
@@ -262,7 +262,7 @@ class LazyFluentIterable<T> implements FluentIterable<T> {
   indexOf(query: T, fromIndex: number = 0): number {
     if (fromIndex < 0) {
       let index = 0;
-      const queue = new Denque();
+      const queue = new Queue();
       for (const elem of this) {
         if (index >= -fromIndex) {
           queue.shift();
@@ -270,7 +270,7 @@ class LazyFluentIterable<T> implements FluentIterable<T> {
         queue.push(elem);
         index++;
       }
-      const ind = queue.toArray().indexOf(query);
+      const ind = [...queue].indexOf(query);
       if (ind === -1) {
         return -1;
       } else {
@@ -304,12 +304,12 @@ class LazyFluentIterable<T> implements FluentIterable<T> {
   lastIndexOf(query: T, fromIndex: number = Infinity): number {
     let lastIndex = -1;
     if (fromIndex < 0) {
-      const queue = new Denque();
+      const queue = new Queue();
       for (const [index, element] of this.gentries()) {
         if (element === query) {
           queue.push(index);
         }
-        const next = queue.peekFront();
+        const next = queue.get(0) as number;
         if (next !== undefined && next <= index + fromIndex + 1) {
           queue.shift();
           lastIndex = next;
@@ -418,11 +418,12 @@ class LazyFluentIterable<T> implements FluentIterable<T> {
   }
 
   private *gnegslice(start: number, end: number): Generator<T> {
-    const queue = new Denque();
+    const queue = new Queue();
     const pop = start - end;
+
     for (const [index, elem] of this.gentries()) {
       if (index >= pop) {
-        yield queue.shift();
+        yield queue.shift() as T;
         queue.push(elem);
       } else if (index >= start) {
         queue.push(elem);
@@ -433,7 +434,7 @@ class LazyFluentIterable<T> implements FluentIterable<T> {
   slice(start: number = 0, end: number = Infinity): FluentIterable<T> {
     if (start < 0) {
       let index = 0;
-      const queue = new Denque();
+      const queue = new Queue<T>();
       for (const elem of this) {
         if (index >= -start) {
           queue.shift();
@@ -441,7 +442,7 @@ class LazyFluentIterable<T> implements FluentIterable<T> {
         queue.push(elem);
         index++;
       }
-      const array = queue.toArray();
+      const array = [...queue];
       const num = end - index - start;
       if (end < 0) {
         return fluent(array.slice(0, end));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1901,11 +1901,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-denque@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
-  integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
-
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -3659,6 +3654,11 @@ quadprog@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/quadprog/-/quadprog-1.6.1.tgz#1cd3b13700de9553ef939a6fa73d0d55ddb2f082"
   integrity sha512-fN5Jkcjlln/b3pJkseDKREf89JkKIyu6cKIVXisgL6ocKPQ0yTp9n6NZUAq3otEPPw78WZMG9K0o9WsfKyMWJw==
+
+quetie@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/quetie/-/quetie-0.1.0.tgz#62f33d4016b064da996e5fb1fb0dd380375f016a"
+  integrity sha512-7CUtc44TgRj+RrWSjJdtI5M2cGHVVe6nR1m/728fzxYqaPPKyY3JOKJ7zxYkTXBwzaKBt5j/xxIGfxZoDG1eig==
 
 queue-microtask@^1.2.2:
   version "1.2.3"


### PR DESCRIPTION
I used the following commands to compute bundle size:
```sh
$ cat file | wc -c | numfmt --to=iec-i --format='%.2f' # original
$ cat file | gzip -9f | wc -c | numfmt --to=iec-i --format='%.2f' # gzipped
```

Note: the right-hand side of each arrow is the gzipped size.

Before this PR:
```
d3-dag.iife.min.js: 84.94kb -> 25.66kb
d3-dag.cjs.min.js: 85.02kb -> 25.67kb
d3-dag.esm.min.js: 84.79kb -> 25.53kb
```

After this PR (percentages are % change from numbers above):
```
d3-dag.iife.min.js: 80.34kb (-5.4%) -> 24.62kb (-4.1%)
d3-dag.cjs.min.js: 80.42kb (-5.4%) -> 24.65 (-4.0%)
d3-dag.esm.min.js: 80.19kb (-5.4%) -> 24.53 (-4.0%)
```

All tests passed locally! :100: 