### PR TITLE
Restore support for TypeScript versions before 4.5

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,101 +32,70 @@
  *
  * @packageDocumentation
  */
-export { type Dag, type DagLink, type DagNode } from "./dag";
+export type { Dag, DagLink, DagNode } from "./dag";
 export {
   connect as dagConnect,
   hierarchy as dagHierarchy,
   stratify as dagStratify,
-  type ConnectOperator,
-  type HierarchyOperator,
-  type StratifyOperator,
 } from "./dag/create";
-export { grid, type GridOperator } from "./grid";
-export { type LaneOperator } from "./grid/lane";
-export {
-  greedy as laneGreedy,
-  type GreedyOperator as GreedyLaneOperator,
-} from "./grid/lane/greedy";
-export {
-  opt as laneOpt,
-  type OptOperator as OptLaneOperator,
-} from "./grid/lane/opt";
-export {
-  coordVertical as sugiCoordVertical,
-  sugiyama,
-  type NodeSizeAccessor,
-  type SugiNodeSizeAccessor,
-  type SugiyamaOperator,
+export type {
+  ConnectOperator,
+  HierarchyOperator,
+  StratifyOperator,
+} from "./dag/create";
+export { grid } from "./grid";
+export type { GridOperator } from "./grid";
+export type { LaneOperator } from "./grid/lane";
+export { greedy as laneGreedy } from "./grid/lane/greedy";
+export type { GreedyOperator as GreedyLaneOperator } from "./grid/lane/greedy";
+export { opt as laneOpt } from "./grid/lane/opt";
+export type { OptOperator as OptLaneOperator } from "./grid/lane/opt";
+export { coordVertical as sugiCoordVertical, sugiyama } from "./sugiyama";
+export type {
+  NodeSizeAccessor,
+  SugiNodeSizeAccessor,
+  SugiyamaOperator,
 } from "./sugiyama";
-export {
-  type CoordNodeSizeAccessor,
-  type CoordOperator,
-} from "./sugiyama/coord";
-export {
-  center as coordCenter,
-  type CenterOperator as CenterCoordOperator,
-} from "./sugiyama/coord/center";
-export {
-  greedy as coordGreedy,
-  type GreedyOperator as GreedyCoordOperator,
-} from "./sugiyama/coord/greedy";
-export {
-  quad as coordQuad,
-  type QuadOperator as QuadCoordOperator,
-} from "./sugiyama/coord/quad";
-export {
-  simplex as coordSimplex,
-  type SimplexOperator as SimplexCoordOperator,
-} from "./sugiyama/coord/simplex";
-export {
-  topological as coordTopological,
-  type TopologicalOperator as TopologicalCoordOperator,
-} from "./sugiyama/coord/topological";
-export { type DecrossOperator } from "./sugiyama/decross";
-export {
-  dfs as decrossDfs,
-  type DfsOperator as DfsDecrossOperator,
-} from "./sugiyama/decross/dfs";
-export {
-  opt as decrossOpt,
-  type OptOperator as OptDecrossOperator,
-} from "./sugiyama/decross/opt";
-export {
-  twoLayer as decrossTwoLayer,
-  type TwoLayerOperator as TwoLayerDecrossOperator,
-} from "./sugiyama/decross/two-layer";
-export { type LayeringOperator } from "./sugiyama/layering";
-export {
-  coffmanGraham as layeringCoffmanGraham,
-  type CoffmanGrahamOperator as CoffmanGrahamLayeringOperator,
-} from "./sugiyama/layering/coffman-graham";
-export {
-  longestPath as layeringLongestPath,
-  type LongestPathOperator as LongestPathLayeringOperator,
-} from "./sugiyama/layering/longest-path";
-export {
-  simplex as layeringSimplex,
-  type SimplexOperator as SimplexLayeringOperator,
-} from "./sugiyama/layering/simplex";
-export {
-  topological as layeringTopological,
-  type TopologicalOperator as TopologicalLayeringOperator,
-} from "./sugiyama/layering/topological";
-export { type TwolayerOperator } from "./sugiyama/twolayer";
+export type { CoordNodeSizeAccessor, CoordOperator } from "./sugiyama/coord";
+export { center as coordCenter } from "./sugiyama/coord/center";
+export type { CenterOperator as CenterCoordOperator } from "./sugiyama/coord/center";
+export { greedy as coordGreedy } from "./sugiyama/coord/greedy";
+export type { GreedyOperator as GreedyCoordOperator } from "./sugiyama/coord/greedy";
+export { quad as coordQuad } from "./sugiyama/coord/quad";
+export type { QuadOperator as QuadCoordOperator } from "./sugiyama/coord/quad";
+export { simplex as coordSimplex } from "./sugiyama/coord/simplex";
+export type { SimplexOperator as SimplexCoordOperator } from "./sugiyama/coord/simplex";
+export { topological as coordTopological } from "./sugiyama/coord/topological";
+export type { TopologicalOperator as TopologicalCoordOperator } from "./sugiyama/coord/topological";
+export type { DecrossOperator } from "./sugiyama/decross";
+export { dfs as decrossDfs } from "./sugiyama/decross/dfs";
+export type { DfsOperator as DfsDecrossOperator } from "./sugiyama/decross/dfs";
+export { opt as decrossOpt } from "./sugiyama/decross/opt";
+export type { OptOperator as OptDecrossOperator } from "./sugiyama/decross/opt";
+export { twoLayer as decrossTwoLayer } from "./sugiyama/decross/two-layer";
+export type { TwoLayerOperator as TwoLayerDecrossOperator } from "./sugiyama/decross/two-layer";
+export type { LayeringOperator } from "./sugiyama/layering";
+export { coffmanGraham as layeringCoffmanGraham } from "./sugiyama/layering/coffman-graham";
+export type { CoffmanGrahamOperator as CoffmanGrahamLayeringOperator } from "./sugiyama/layering/coffman-graham";
+export { longestPath as layeringLongestPath } from "./sugiyama/layering/longest-path";
+export type { LongestPathOperator as LongestPathLayeringOperator } from "./sugiyama/layering/longest-path";
+export { simplex as layeringSimplex } from "./sugiyama/layering/simplex";
+export type { SimplexOperator as SimplexLayeringOperator } from "./sugiyama/layering/simplex";
+export { topological as layeringTopological } from "./sugiyama/layering/topological";
+export type { TopologicalOperator as TopologicalLayeringOperator } from "./sugiyama/layering/topological";
+export type { TwolayerOperator } from "./sugiyama/twolayer";
 export {
   agg as twolayerAgg,
   meanFactory as aggMeanFactory,
   medianFactory as aggMedianFactory,
   weightedMedianFactory as aggWeightedMedianFactory,
-  type AggOperator as AggTwolayerOperator,
 } from "./sugiyama/twolayer/agg";
-export {
-  greedy as twolayerGreedy,
-  type GreedyOperator as GreedyTwolayerOperator,
-} from "./sugiyama/twolayer/greedy";
-export {
-  opt as twolayerOpt,
-  type OptOperator as OptTwolayerOperator,
-} from "./sugiyama/twolayer/opt";
-export { sugify, unsugify, type SugiNode } from "./sugiyama/utils";
-export { zherebko, type ZherebkoOperator } from "./zherebko";
+export type { AggOperator as AggTwolayerOperator } from "./sugiyama/twolayer/agg";
+export { greedy as twolayerGreedy } from "./sugiyama/twolayer/greedy";
+export type { GreedyOperator as GreedyTwolayerOperator } from "./sugiyama/twolayer/greedy";
+export { opt as twolayerOpt } from "./sugiyama/twolayer/opt";
+export type { OptOperator as OptTwolayerOperator } from "./sugiyama/twolayer/opt";
+export { sugify, unsugify } from "./sugiyama/utils";
+export type { SugiNode } from "./sugiyama/utils";
+export { zherebko } from "./zherebko";
+export type { ZherebkoOperator } from "./zherebko";


### PR DESCRIPTION
Support for the `type` modifier on exports/imports was only [added in TypeScript 4.5](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names), so separate the regular and `type` exports (i.e. revert [changes to `src/index.ts`](https://github.com/erikbrinkman/d3-dag/commit/37cc714a0e0baf7429e3119c40c5c14f3ea21d88#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) from 37cc714a0e0baf7429e3119c40c5c14f3ea21d88) to restore support for earlier TypeScript versions.

Resolves https://github.com/erikbrinkman/d3-dag/issues/95.